### PR TITLE
chore(license): apply proper licensing and giving polkadot-js copyright credit

### DIFF
--- a/config/babel.js
+++ b/config/babel.js
@@ -1,3 +1,5 @@
+// Copyright 2022 Parity Technologies (UK) Ltd.
+
 module.exports = {
 	// Convert ESM -> CJS; Specifically for @polkadot >= v4 where ESM becomes default
 	"plugins": ["@babel/plugin-transform-modules-commonjs"]

--- a/config/eslint.js
+++ b/config/eslint.js
@@ -1,3 +1,5 @@
+// Copyright 2022 Parity Technologies (UK) Ltd.
+
 module.exports = {
 	extends: [
 		'eslint:recommended',

--- a/config/jest.js
+++ b/config/jest.js
@@ -1,3 +1,5 @@
+// Copyright 2022 Parity Technologies (UK) Ltd.
+
 module.exports = {
 	preset: 'ts-jest/presets/js-with-babel',
 	transformIgnorePatterns: ['<rootDir>/node_modules/(?!@polkadot|@babel/runtime/helpers/esm/)'],

--- a/config/prettier.js
+++ b/config/prettier.js
@@ -1,3 +1,5 @@
+// Copyright 2022 Parity Technologies (UK) Ltd.
+
 module.exports = {
 	semi: true,
 	singleQuote: true,

--- a/scripts/execSync.cjs
+++ b/scripts/execSync.cjs
@@ -1,4 +1,12 @@
 #!/usr/bin/env node
+// Copyright 2022 Parity Technologies (UK) Ltd.
+
+// Copyright 2017-2022 @polkadot/dev authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+//
+// This has been converted from the original version which can be found here:
+//
+// https://github.com/polkadot-js/dev/blob/ce1831b8d17a41211f99fa71551450524d9bb61e/packages/dev/scripts/execSync.mjs
 
 const { execSync } = require('child_process');
 

--- a/scripts/importBinary.cjs
+++ b/scripts/importBinary.cjs
@@ -1,3 +1,13 @@
+#!/usr/bin/env node
+// Copyright 2022 Parity Technologies (UK) Ltd.
+
+// Copyright 2017-2022 @polkadot/dev authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+//
+// This has been converted from the original version which can be found here:
+//
+// https://github.com/polkadot-js/dev/blob/ce1831b8d17a41211f99fa71551450524d9bb61e/packages/dev/scripts/import.cjs
+
 const path = require('path');
 
 module.exports = function importBinary (bin, dir) {

--- a/scripts/substrate-dev-run-lint.cjs
+++ b/scripts/substrate-dev-run-lint.cjs
@@ -1,4 +1,12 @@
 #!/usr/bin/env node
+// Copyright 2022 Parity Technologies (UK) Ltd.
+
+// Copyright 2017-2022 @polkadot/dev authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+//
+// This has been converted from the original version which can be found here:
+//
+// https://github.com/polkadot-js/dev/blob/ce1831b8d17a41211f99fa71551450524d9bb61e/packages/dev/scripts/polkadot-dev-run-lint.mjs
 
 const execSync = require('./execSync.cjs');
 

--- a/scripts/substrate-exec-eslint.cjs
+++ b/scripts/substrate-exec-eslint.cjs
@@ -1,4 +1,13 @@
 #!/usr/bin/env node
+// Copyright 2022 Parity Technologies (UK) Ltd.
+
+// Copyright 2017-2022 @polkadot/dev authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+//
+// This has been converted from the original version which can be found here:
+//
+// https://github.com/polkadot-js/dev/blob/ce1831b8d17a41211f99fa71551450524d9bb61e/packages/dev/scripts/polkadot-exec-eslint.mjs
+
 const importBinary = require('./importBinary.cjs');
 
 importBinary('eslint', 'eslint/bin/eslint');

--- a/scripts/substrate-exec-jest.cjs
+++ b/scripts/substrate-exec-jest.cjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+// Copyright 2022 Parity Technologies (UK) Ltd.
+
 const importBinary = require('./importBinary.cjs');
 
 importBinary('jest', 'jest-cli/bin/jest');

--- a/scripts/substrate-exec-rimraf.cjs
+++ b/scripts/substrate-exec-rimraf.cjs
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+
+// Copyright 2022 Parity Technologies (UK) Ltd.
+
 const importBinary = require('./importBinary.cjs');
 
 importBinary('rimraf', 'rimraf/bin');

--- a/scripts/substrate-exec-rimraf.cjs
+++ b/scripts/substrate-exec-rimraf.cjs
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-
 // Copyright 2022 Parity Technologies (UK) Ltd.
 
 const importBinary = require('./importBinary.cjs');

--- a/scripts/substrate-exec-tsc.cjs
+++ b/scripts/substrate-exec-tsc.cjs
@@ -1,4 +1,13 @@
 #!/usr/bin/env node
+// Copyright 2022 Parity Technologies (UK) Ltd.
+
+// Copyright 2017-2022 @polkadot/dev authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+//
+// This has been converted from the original version which can be found here:
+//
+// https://github.com/polkadot-js/dev/blob/ce1831b8d17a41211f99fa71551450524d9bb61e/packages/dev/scripts/polkadot-exec-tsc.mjs
+
 const importBinary = require('./importBinary.cjs');
 
 importBinary('tsc', 'typescript/lib/tsc');

--- a/scripts/substrate-update-pjs-deps.cjs
+++ b/scripts/substrate-update-pjs-deps.cjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+// Copyright 2022 Parity Technologies (UK) Ltd.
+
 'use strict';
 
 const fs = require('fs');


### PR DESCRIPTION
This puts the license at the top of each file, but also gives polkadot-js the proper credit for code that was adopted from `@polkadot/dev`.