### PR TITLE
fix: let dev run lint take in any args

### DIFF
--- a/scripts/substrate-dev-run-lint.cjs
+++ b/scripts/substrate-dev-run-lint.cjs
@@ -9,17 +9,6 @@
 // https://github.com/polkadot-js/dev/blob/ce1831b8d17a41211f99fa71551450524d9bb61e/packages/dev/scripts/polkadot-dev-run-lint.mjs
 
 const execSync = require('./execSync.cjs');
+const args = process.argv.slice(2).join(' ');
 
-const argv = require('yargs')
-    .options({
-        '--fix': {
-            description: 'Eslint --fix flag',
-            type: 'boolean'
-        }
-    })
-    .strict()
-    .argv;
-
-const fix = argv.fix ? '--fix' : '';
-
-execSync(`yarn substrate-exec-tsc --noEmit && substrate-exec-eslint . --ext ts ${fix}`);
+execSync(`yarn substrate-exec-tsc --noEmit && substrate-exec-eslint . --ext ts ${args}`);

--- a/scripts/substrate-dev-run-lint.cjs
+++ b/scripts/substrate-dev-run-lint.cjs
@@ -11,4 +11,12 @@
 const execSync = require('./execSync.cjs');
 const args = process.argv.slice(2).join(' ');
 
-execSync(`yarn substrate-exec-tsc --noEmit && substrate-exec-eslint . --ext ts ${args}`);
+const checkArgs = process.argv.slice(2).filter((val) => {
+    return val.split(' ').length > 1;
+});
+
+if (checkArgs.length === 0) {
+    execSync(`yarn substrate-exec-tsc --noEmit && substrate-exec-eslint . --ext ts ${args}`);
+} else {
+    console.warn(`Incorrect input. String arguments can't have spaces: ${checkArgs.join(' - ')}`)
+}


### PR DESCRIPTION
Sets `substrate-dev-run-lint` to accept any set of args. 