### PR TITLE
fix: write a custom rimraf

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
-    "rimraf": "^5.0.10",
     "ts-jest": "^29.2.5",
     "typescript": "^5.6.2",
     "yargs": "^17.7.2"

--- a/scripts/substrate-exec-rimraf.cjs
+++ b/scripts/substrate-exec-rimraf.cjs
@@ -4,10 +4,16 @@ const fs = require('fs');
 
 (function() {
     const dirs = process.argv.slice(2);
+
+    if (!dirs.length) {
+        throw new Error(`rimraf-exec: Invalid args length: retrieved ${dirs.length}`)
+    }
     
     for (const dir of dirs) {
         if (fs.existsSync(dir)) {
           fs.rmSync(dir, { force: true, recursive: true });
+        } else {
+            console.warn(`rimraf-exec: ${dir} is an invalid file path and does not exist`)
         }
     }
 })();

--- a/scripts/substrate-exec-rimraf.cjs
+++ b/scripts/substrate-exec-rimraf.cjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Copyright 2022 Parity Technologies (UK) Ltd.
+// Copyright 2024 Parity Technologies (UK) Ltd.
 const fs = require('fs');
 
 (function() {

--- a/scripts/substrate-exec-rimraf.cjs
+++ b/scripts/substrate-exec-rimraf.cjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 // Copyright 2024 Parity Technologies (UK) Ltd.
+
 const fs = require('fs');
 
 (function() {

--- a/scripts/substrate-exec-rimraf.cjs
+++ b/scripts/substrate-exec-rimraf.cjs
@@ -1,6 +1,13 @@
 #!/usr/bin/env node
 // Copyright 2022 Parity Technologies (UK) Ltd.
+const fs = require('fs');
 
-const importBinary = require('./importBinary.cjs');
-
-importBinary('rimraf', 'rimraf/bin');
+(function() {
+    const dirs = process.argv.slice(2);
+    
+    for (const dir of dirs) {
+        if (fs.existsSync(dir)) {
+          fs.rmSync(dir, { force: true, recursive: true });
+        }
+    }
+})();

--- a/scripts/substrate-exec-rimraf.cjs
+++ b/scripts/substrate-exec-rimraf.cjs
@@ -12,6 +12,7 @@ const fs = require('fs');
     
     for (const dir of dirs) {
         if (fs.existsSync(dir)) {
+          console.log(`rimraf-exec: ${dir}`)
           fs.rmSync(dir, { force: true, recursive: true });
         } else {
             console.warn(`rimraf-exec: ${dir} is an invalid file path and does not exist`)

--- a/yarn.lock
+++ b/yarn.lock
@@ -894,7 +894,6 @@ __metadata:
     eslint-plugin-simple-import-sort: "npm:^12.1.1"
     jest: "npm:^29.7.0"
     prettier: "npm:^3.3.3"
-    rimraf: "npm:^5.0.10"
     ts-jest: "npm:^29.2.5"
     typescript: "npm:^5.6.2"
     yargs: "npm:^17.7.2"
@@ -2266,7 +2265,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^10.2.2, glob@npm:^10.3.10, glob@npm:^10.3.7":
+"glob@npm:^10.2.2, glob@npm:^10.3.10":
   version: 10.4.5
   resolution: "glob@npm:10.4.5"
   dependencies:
@@ -3914,17 +3913,6 @@ __metadata:
   bin:
     rimraf: bin.js
   checksum: 10/063ffaccaaaca2cfd0ef3beafb12d6a03dd7ff1260d752d62a6077b5dfff6ae81bea571f655bb6b589d366930ec1bdd285d40d560c0dae9b12f125e54eb743d5
-  languageName: node
-  linkType: hard
-
-"rimraf@npm:^5.0.10":
-  version: 5.0.10
-  resolution: "rimraf@npm:5.0.10"
-  dependencies:
-    glob: "npm:^10.3.7"
-  bin:
-    rimraf: dist/esm/bin.mjs
-  checksum: 10/f3b8ce81eecbde4628b07bdf9e2fa8b684e0caea4999acb1e3b0402c695cd41f28cd075609a808e61ce2672f528ca079f675ab1d8e8d5f86d56643a03e0b8d2e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Wrote a custom version of rimraf to fit our specific use case to avoid the issue in https://github.com/paritytech/substrate-js-dev/issues/119.

Also I think it fits my philosophy of removing as many deps as we can. Generally I think removing any dep when we can is a plus.